### PR TITLE
feat: organize experiment directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ python main.py --mode eval --dataset afhq --num_domains 3 --w_hpf 0 \
                --expr_dir expr/afhq_experiment --resume_iter 100000
 ```
 
+LPIPS requires at least two outputs per source image. If `--num_outs_per_domain < 2`,
+LPIPS is skipped and only FID is reported.
+
 Note that the evaluation metrics are calculated using random latent vectors or reference images, both of which are selected by the [seed number](https://github.com/clovaai/stargan-v2/blob/master/main.py#L35). In the paper, we reported the average of values from 10 measurements using different seed numbers. The following table shows the calculated values for both latent-guided and reference-guided synthesis.
 
 | Dataset <img width=50/> | <img width=15/> FID (latent) <img width=15/>  | <img width=10/> LPIPS (latent) <img width=10/> | <img width=5/> FID (reference) <img width=5/> | LPIPS (reference) | <img width=10/> Elapsed time <img width=10/>  |

--- a/README.md
+++ b/README.md
@@ -69,9 +69,8 @@ After downloading the pre-trained networks, you can synthesize output images ref
 
 <b>CelebA-HQ.</b> To generate images and interpolation videos, run the following command:
 ```bash
-python main.py --mode sample --num_domains 2 --resume_iter 100000 --w_hpf 1 \
-               --checkpoint_dir expr/checkpoints/celeba_hq \
-               --result_dir expr/results/celeba_hq \
+python main.py --mode sample --dataset celeba_hq --num_domains 2 --w_hpf 1 \
+               --expr_dir expr/celeba_hq_experiment --resume_iter 100000 \
                --src_dir assets/representative/celeba_hq/src \
                --ref_dir assets/representative/celeba_hq/ref
 ```
@@ -90,9 +89,8 @@ python main.py --mode align \
 
 <b>AFHQ.</b> To generate images and interpolation videos, run the following command:
 ```bash
-python main.py --mode sample --num_domains 3 --resume_iter 100000 --w_hpf 0 \
-               --checkpoint_dir expr/checkpoints/afhq \
-               --result_dir expr/results/afhq \
+python main.py --mode sample --dataset afhq --num_domains 3 --w_hpf 0 \
+               --expr_dir expr/afhq_experiment --resume_iter 100000 \
                --src_dir assets/representative/afhq/src \
                --ref_dir assets/representative/afhq/ref
 ```
@@ -105,20 +103,12 @@ To evaluate StarGAN v2 using [Fr&eacute;chet Inception Distance (FID)](https://a
 
 ```bash
 # celeba-hq
-python main.py --mode eval --num_domains 2 --w_hpf 1 \
-               --resume_iter 100000 \
-               --train_img_dir data/celeba_hq/train \
-               --val_img_dir data/celeba_hq/val \
-               --checkpoint_dir expr/checkpoints/celeba_hq \
-               --eval_dir expr/eval/celeba_hq
+python main.py --mode eval --dataset celeba_hq --num_domains 2 --w_hpf 1 \
+               --expr_dir expr/celeba_hq_experiment --resume_iter 100000
 
 # afhq
-python main.py --mode eval --num_domains 3 --w_hpf 0 \
-               --resume_iter 100000 \
-               --train_img_dir data/afhq/train \
-               --val_img_dir data/afhq/val \
-               --checkpoint_dir expr/checkpoints/afhq \
-               --eval_dir expr/eval/afhq
+python main.py --mode eval --dataset afhq --num_domains 3 --w_hpf 0 \
+               --expr_dir expr/afhq_experiment --resume_iter 100000
 ```
 
 Note that the evaluation metrics are calculated using random latent vectors or reference images, both of which are selected by the [seed number](https://github.com/clovaai/stargan-v2/blob/master/main.py#L35). In the paper, we reported the average of values from 10 measurements using different seed numbers. The following table shows the calculated values for both latent-guided and reference-guided synthesis.
@@ -131,20 +121,16 @@ Note that the evaluation metrics are calculated using random latent vectors or r
 
 
 ## Training networks
-To train StarGAN v2 from scratch, run the following commands. Generated images and network checkpoints will be stored in the `expr/samples` and `expr/checkpoints` directories, respectively. Training takes about three days on a single Tesla V100 GPU. Please see [here](https://github.com/clovaai/stargan-v2/blob/master/main.py#L86-L179) for training arguments and a description of them. 
+To train StarGAN v2 from scratch, run the following commands. By default, the code expects datasets to be placed under `data/<dataset>/train` and `data/<dataset>/val` and stores all experiment artifacts under `expr/<dataset>_<timestamp>/`. You can override the root experiment directory with `--expr_dir` if needed. Training takes about three days on a single Tesla V100 GPU. Please see [here](https://github.com/clovaai/stargan-v2/blob/master/main.py#L86-L179) for training arguments and a description of them.
 
 ```bash
 # celeba-hq
-python main.py --mode train --num_domains 2 --w_hpf 1 \
-               --lambda_reg 1 --lambda_sty 1 --lambda_ds 1 --lambda_cyc 1 \
-               --train_img_dir data/celeba_hq/train \
-               --val_img_dir data/celeba_hq/val
+python main.py --mode train --dataset celeba_hq --num_domains 2 --w_hpf 1 \
+               --lambda_reg 1 --lambda_sty 1 --lambda_ds 1 --lambda_cyc 1
 
 # afhq
-python main.py --mode train --num_domains 3 --w_hpf 0 \
-               --lambda_reg 1 --lambda_sty 1 --lambda_ds 2 --lambda_cyc 1 \
-               --train_img_dir data/afhq/train \
-               --val_img_dir data/afhq/val
+python main.py --mode train --dataset afhq --num_domains 3 --w_hpf 0 \
+               --lambda_reg 1 --lambda_sty 1 --lambda_ds 2 --lambda_cyc 1
 ```
 
 ## Animal Faces-HQ dataset (AFHQ)

--- a/main.py
+++ b/main.py
@@ -205,7 +205,7 @@ if __name__ == '__main__':
     if args.val_img_dir is None:
         args.val_img_dir = os.path.join('data', args.dataset, 'val')
 
-    timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
+    timestamp = datetime.now().strftime('%m%d-%H%M')
     if args.expr_dir is None:
         args.expr_dir = os.path.join('expr', f'{args.dataset}_{timestamp}')
     if args.sample_dir is None:

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 
 import os
 import argparse
+from datetime import datetime
 
 from munch import Munch
 from torch.backends import cudnn
@@ -154,22 +155,28 @@ if __name__ == '__main__':
     parser.add_argument('--seed', type=int, default=777,
                         help='Seed for random number generator')
 
+    # dataset and experiment directory
+    parser.add_argument('--dataset', type=str, default='celeba_hq',
+                        help='Name of the dataset, e.g., celeba_hq or afhq')
+    parser.add_argument('--expr_dir', type=str, default=None,
+                        help='Root directory for saving experiments')
+
     # directory for training
-    parser.add_argument('--train_img_dir', type=str, default='data/celeba_hq/train',
+    parser.add_argument('--train_img_dir', type=str, default=None,
                         help='Directory containing training images')
-    parser.add_argument('--val_img_dir', type=str, default='data/celeba_hq/val',
+    parser.add_argument('--val_img_dir', type=str, default=None,
                         help='Directory containing validation images')
-    parser.add_argument('--sample_dir', type=str, default='expr/samples',
+    parser.add_argument('--sample_dir', type=str, default=None,
                         help='Directory for saving generated images')
-    parser.add_argument('--checkpoint_dir', type=str, default='expr/checkpoints',
+    parser.add_argument('--checkpoint_dir', type=str, default=None,
                         help='Directory for saving network checkpoints')
 
     # directory for calculating metrics
-    parser.add_argument('--eval_dir', type=str, default='expr/eval',
+    parser.add_argument('--eval_dir', type=str, default=None,
                         help='Directory for saving metrics, i.e., FID and LPIPS')
 
     # directory for testing
-    parser.add_argument('--result_dir', type=str, default='expr/results',
+    parser.add_argument('--result_dir', type=str, default=None,
                         help='Directory for saving generated images and videos')
     parser.add_argument('--src_dir', type=str, default='assets/representative/celeba_hq/src',
                         help='Directory containing input source images')
@@ -188,9 +195,27 @@ if __name__ == '__main__':
     parser.add_argument('--print_every', type=int, default=10)
     parser.add_argument('--sample_every', type=int, default=5000)
     parser.add_argument('--save_every', type=int, default=10000)
-    parser.add_argument('--eval_every', type=int, default=50000)
+    parser.add_argument('--eval_every', type=int, default=100000)
 
     args = parser.parse_args()
+
+    # set default directories based on dataset and experiment timestamp
+    if args.train_img_dir is None:
+        args.train_img_dir = os.path.join('data', args.dataset, 'train')
+    if args.val_img_dir is None:
+        args.val_img_dir = os.path.join('data', args.dataset, 'val')
+
+    timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
+    if args.expr_dir is None:
+        args.expr_dir = os.path.join('expr', f'{args.dataset}_{timestamp}')
+    if args.sample_dir is None:
+        args.sample_dir = os.path.join(args.expr_dir, 'samples')
+    if args.checkpoint_dir is None:
+        args.checkpoint_dir = os.path.join(args.expr_dir, 'checkpoints')
+    if args.eval_dir is None:
+        args.eval_dir = os.path.join(args.expr_dir, 'eval')
+    if args.result_dir is None:
+        args.result_dir = os.path.join(args.expr_dir, 'results')
 
     def _round16(x):
         return int(round(x / 16) * 16)

--- a/metrics/eval.py
+++ b/metrics/eval.py
@@ -130,17 +130,23 @@ def calculate_fid_for_all_tasks(args, domains, step, mode):
             path_real = os.path.join(args.train_img_dir, trg_domain)
             path_fake = os.path.join(args.eval_dir, task)
             print('Calculating FID for %s...' % task)
-            fid_value = calculate_fid_given_paths(
+            fid_value, counts = calculate_fid_given_paths(
                 paths=[path_real, path_fake],
                 img_size=(args.img_height, args.img_width),
                 batch_size=args.val_batch_size)
-            fid_values['FID_%s/%s' % (mode, task)] = fid_value
+            n_real, n_fake = counts
+            key = 'FID_%s/%s' % (mode, task)
+            fid_values[key] = {
+                'value': fid_value,
+                'N_real': n_real,
+                'N_fake': n_fake
+            }
+            print('%s: %.4f (N_real=%d, N_fake=%d)' % (key, fid_value, n_real, n_fake))
 
     # calculate the average FID for all tasks
-    fid_mean = 0
-    for _, value in fid_values.items():
-        fid_mean += value / len(fid_values)
+    fid_mean = sum(v['value'] for v in fid_values.values()) / len(fid_values) if fid_values else 0
     fid_values['FID_%s/mean' % mode] = fid_mean
+    print('FID_%s/mean: %.4f' % (mode, fid_mean))
 
     # report FID values
     filename = os.path.join(args.eval_dir, 'FID_%.5i_%s.json' % (step, mode))

--- a/metrics/eval.py
+++ b/metrics/eval.py
@@ -32,6 +32,10 @@ def calculate_metrics(nets, args, step, mode):
     num_domains = len(domains)
     print('Number of domains: %d' % num_domains)
 
+    skip_lpips = args.num_outs_per_domain < 2
+    if skip_lpips:
+        print('Skipping LPIPS because num_outs_per_domain < 2')
+
     lpips_dict = OrderedDict()
     for trg_idx, trg_domain in enumerate(domains):
         src_domains = [x for x in domains if x != trg_domain]
@@ -56,7 +60,11 @@ def calculate_metrics(nets, args, step, mode):
             os.makedirs(path_fake, exist_ok=True)
 
             lpips_values = []
-            print('Generating images and calculating LPIPS for %s...' % task)
+            if skip_lpips:
+                print('Generating images for %s (LPIPS skipped)...' % task)
+            else:
+                print('Generating images and calculating LPIPS for %s...' % task)
+
             for i, x_src in enumerate(tqdm(loader_src, total=len(loader_src))):
                 N = x_src.size(0)
                 x_src = x_src.to(device)
@@ -90,11 +98,15 @@ def calculate_metrics(nets, args, step, mode):
                             '%.4i_%.2i.png' % (i*args.val_batch_size+(k+1), j+1))
                         utils.save_image(x_fake[k], ncol=1, filename=filename)
 
-                lpips_value = calculate_lpips_given_images(group_of_images)
-                lpips_values.append(lpips_value)
+                if not skip_lpips:
+                    lpips_value = calculate_lpips_given_images(group_of_images)
+                    lpips_values.append(lpips_value)
 
             # calculate LPIPS for each task (e.g. cat2dog, dog2cat)
-            lpips_mean = np.array(lpips_values).mean()
+            if not skip_lpips and lpips_values:
+                lpips_mean = np.array(lpips_values).mean()
+            else:
+                lpips_mean = None
             lpips_dict['LPIPS_%s/%s' % (mode, task)] = lpips_mean
 
         # delete dataloaders
@@ -104,10 +116,13 @@ def calculate_metrics(nets, args, step, mode):
             del iter_ref
 
     # calculate the average LPIPS for all tasks
-    lpips_mean = 0
-    for _, value in lpips_dict.items():
-        lpips_mean += value / len(lpips_dict)
+    valid_lpips = [v for v in lpips_dict.values() if v is not None]
+    lpips_mean = sum(valid_lpips) / len(valid_lpips) if valid_lpips else None
     lpips_dict['LPIPS_%s/mean' % mode] = lpips_mean
+    if lpips_mean is None:
+        print('LPIPS_%s/mean: skipped' % mode)
+    else:
+        print('LPIPS_%s/mean: %.4f' % (mode, lpips_mean))
 
     # report LPIPS values
     filename = os.path.join(args.eval_dir, 'LPIPS_%.5i_%s.json' % (step, mode))

--- a/metrics/eval.py
+++ b/metrics/eval.py
@@ -9,7 +9,6 @@ Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
 """
 
 import os
-import shutil
 from collections import OrderedDict
 from tqdm import tqdm
 
@@ -53,9 +52,8 @@ def calculate_metrics(nets, args, step, mode):
                                          imagenet_normalize=False)
 
             task = '%s2%s' % (src_domain, trg_domain)
-            path_fake = os.path.join(args.eval_dir, task)
-            shutil.rmtree(path_fake, ignore_errors=True)
-            os.makedirs(path_fake)
+            path_fake = os.path.join(args.eval_dir, mode, task)
+            os.makedirs(path_fake, exist_ok=True)
 
             lpips_values = []
             print('Generating images and calculating LPIPS for %s...' % task)
@@ -128,7 +126,7 @@ def calculate_fid_for_all_tasks(args, domains, step, mode):
         for src_domain in src_domains:
             task = '%s2%s' % (src_domain, trg_domain)
             path_real = os.path.join(args.train_img_dir, trg_domain)
-            path_fake = os.path.join(args.eval_dir, task)
+            path_fake = os.path.join(args.eval_dir, mode, task)
             print('Calculating FID for %s...' % task)
             fid_value, counts = calculate_fid_given_paths(
                 paths=[path_real, path_fake],

--- a/metrics/fid.py
+++ b/metrics/fid.py
@@ -61,10 +61,12 @@ def frechet_distance(mu, cov, mu2, cov2):
 
 @torch.no_grad()
 def calculate_fid_given_paths(paths, img_size=256, batch_size=50):
-    print('Calculating FID given paths %s and %s...' % (paths[0], paths[1]))
+    loaders = [get_eval_loader(path, img_size, batch_size) for path in paths]
+    counts = [len(loader.dataset) for loader in loaders]
+    print('Calculating FID given paths %s (N=%d) and %s (N=%d)...' %
+          (paths[0], counts[0], paths[1], counts[1]))
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     inception = InceptionV3().eval().to(device)
-    loaders = [get_eval_loader(path, img_size, batch_size) for path in paths]
 
     mu, cov = [], []
     for loader in loaders:
@@ -76,7 +78,7 @@ def calculate_fid_given_paths(paths, img_size=256, batch_size=50):
         mu.append(np.mean(actvs, axis=0))
         cov.append(np.cov(actvs, rowvar=False))
     fid_value = frechet_distance(mu[0], cov[0], mu[1], cov[1])
-    return fid_value
+    return fid_value, counts
 
 
 if __name__ == '__main__':
@@ -92,7 +94,7 @@ if __name__ == '__main__':
 
     h = _round16(args.img_size)
     w = _round16(h * args.aspect_ratio)
-    fid_value = calculate_fid_given_paths(args.paths, (h, w), args.batch_size)
-    print('FID: ', fid_value)
+    fid_value, counts = calculate_fid_given_paths(args.paths, (h, w), args.batch_size)
+    print('FID: %s (N_real=%d, N_fake=%d)' % (fid_value, counts[0], counts[1]))
 
 # python -m metrics.fid --paths PATH_REAL PATH_FAKE


### PR DESCRIPTION
## Summary
- add dataset and expr_dir options and derive default paths for data, checkpoints, results, and eval directories
- default evaluation interval is now 100000 iterations
- document dataset-driven workflows for training, sampling, and evaluation
- log the number of images used for each FID computation and include counts in console output and saved JSON

## Testing
- `python -m py_compile metrics/fid.py metrics/eval.py`
- `python main.py -h` *(fails: ModuleNotFoundError: No module named 'munch')*
- `pip install munch` *(ProxyError: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68c0cb9f160c83229feeb111b315d2a9