### PR TITLE
Use source filenames for eval outputs

### DIFF
--- a/core/data_loader.py
+++ b/core/data_loader.py
@@ -51,17 +51,20 @@ class CenterCropResize:
 
 
 class DefaultDataset(data.Dataset):
-    def __init__(self, root, transform=None):
+    def __init__(self, root, transform=None, return_paths=False):
         self.samples = listdir(root)
         self.samples.sort()
         self.transform = transform
         self.targets = None
+        self.return_paths = return_paths
 
     def __getitem__(self, index):
         fname = self.samples[index]
         img = Image.open(fname).convert('RGB')
         if self.transform is not None:
             img = self.transform(img)
+        if self.return_paths:
+            return img, fname.name
         return img
 
     def __len__(self):
@@ -148,7 +151,7 @@ def get_train_loader(root, which='source', img_size=256,
 
 def get_eval_loader(root, img_size=256, batch_size=32,
                     imagenet_normalize=True, shuffle=True,
-                    num_workers=4, drop_last=False):
+                    num_workers=4, drop_last=False, return_paths=False):
     print('Preparing DataLoader for the evaluation phase...')
     if isinstance(img_size, tuple):
         height, width = img_size
@@ -171,7 +174,7 @@ def get_eval_loader(root, img_size=256, batch_size=32,
         transforms.Normalize(mean=mean, std=std)
     ])
 
-    dataset = DefaultDataset(root, transform=transform)
+    dataset = DefaultDataset(root, transform=transform, return_paths=return_paths)
     return data.DataLoader(dataset=dataset,
                            batch_size=batch_size,
                            shuffle=shuffle,

--- a/metrics/eval.py
+++ b/metrics/eval.py
@@ -53,7 +53,8 @@ def calculate_metrics(nets, args, step, mode):
             loader_src = get_eval_loader(root=path_src,
                                          img_size=(args.img_height, args.img_width),
                                          batch_size=args.val_batch_size,
-                                         imagenet_normalize=False)
+                                         imagenet_normalize=False,
+                                         return_paths=True)
 
             task = '%s2%s' % (src_domain, trg_domain)
             path_fake = os.path.join(args.eval_dir, mode, task)
@@ -65,7 +66,7 @@ def calculate_metrics(nets, args, step, mode):
             else:
                 print('Generating images and calculating LPIPS for %s...' % task)
 
-            for i, x_src in enumerate(tqdm(loader_src, total=len(loader_src))):
+            for i, (x_src, fnames) in enumerate(tqdm(loader_src, total=len(loader_src))):
                 N = x_src.size(0)
                 x_src = x_src.to(device)
                 y_trg = torch.tensor([trg_idx] * N).to(device)
@@ -93,9 +94,10 @@ def calculate_metrics(nets, args, step, mode):
 
                     # save generated images to calculate FID later
                     for k in range(N):
+                        basename, _ = os.path.splitext(fnames[k])
                         filename = os.path.join(
                             path_fake,
-                            '%.4i_%.2i.png' % (i*args.val_batch_size+(k+1), j+1))
+                            f"{basename}_{j+1:02d}.png")
                         utils.save_image(x_fake[k], ncol=1, filename=filename)
 
                 if not skip_lpips:


### PR DESCRIPTION
## Summary
- allow evaluation dataloader to optionally return image paths
- name generated eval images with their source filename instead of numeric indices

## Testing
- `python -m py_compile core/data_loader.py metrics/eval.py`


------
https://chatgpt.com/codex/tasks/task_e_68c764550adc8322a0f8c863d61477e1