### PR TITLE
Add generate mode for quick image synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,35 @@ python main.py --mode sample --dataset afhq --num_domains 3 --w_hpf 0 \
 
 <p align="left"><img width="99%" src="assets/afhq_interpolation.gif" /></p>
 
+## Quick generation workflow
+Use the new `generate` mode to quickly synthesize individual outputs for each
+source image. The command below reuses the same directories as the sampling
+examples above but writes per-image results such as `male_000001_01.png` to
+`expr/results`.
+
+```bash
+python main.py --mode generate --dataset celeba_hq --num_domains 2 --w_hpf 1 \
+               --expr_dir expr/celeba_hq_experiment --resume_iter 100000 \
+               --src_dir assets/representative/celeba_hq/src \
+               --ref_dir assets/representative/celeba_hq/ref \
+               --num_samples 3
+```
+
+By default the generator loops over every domain. Provide `--target_domain`
+to restrict the output domains or to switch to latent-guided synthesis when
+no reference directory is available. The example below disables references by
+setting an empty `ref_dir` and produces four latent samples for domain index 1:
+
+```bash
+python main.py --mode generate --dataset celeba_hq --num_domains 2 --w_hpf 1 \
+               --expr_dir expr/celeba_hq_experiment --resume_iter 100000 \
+               --src_dir assets/representative/celeba_hq/src \
+               --ref_dir '' --target_domain 1 --num_samples 4
+```
+
+Each generated image is saved as `<orig_name>_XX.png`, where `orig_name` is
+derived from the original filename and `XX` is a 1-based counter.
+
 ## Evaluation metrics
 To evaluate StarGAN v2 using [Fr&eacute;chet Inception Distance (FID)](https://arxiv.org/abs/1706.08500) and [Learned Perceptual Image Patch Similarity (LPIPS)](https://arxiv.org/abs/1801.03924), run the following commands:
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ python main.py --mode sample --dataset afhq --num_domains 3 --w_hpf 0 \
 
 ## Quick generation workflow
 Use the new `generate` mode to quickly synthesize individual outputs for each
-source image. The command below reuses the same directories as the sampling
-examples above but writes per-image results such as `male_000001_01.png` to
+source image. The source directory may contain images directly (no domain
+sub-folders required). The command below reuses the same directories as the
+sampling examples above but writes per-image results such as `000001_01.png` to
 `expr/results`.
 
 ```bash
@@ -124,7 +125,10 @@ python main.py --mode generate --dataset celeba_hq --num_domains 2 --w_hpf 1 \
 ```
 
 Each generated image is saved as `<orig_name>_XX.png`, where `orig_name` is
-derived from the original filename and `XX` is a 1-based counter.
+derived from the original filename and `XX` is a 1-based counter. When
+reference images are provided, the generator samples random reference styles
+for every output so different source images (and different samples of the same
+source) use varied guidance.
 
 ## Evaluation metrics
 To evaluate StarGAN v2 using [Fr&eacute;chet Inception Distance (FID)](https://arxiv.org/abs/1706.08500) and [Learned Perceptual Image Patch Similarity (LPIPS)](https://arxiv.org/abs/1801.03924), run the following commands:

--- a/core/data_loader.py
+++ b/core/data_loader.py
@@ -24,6 +24,18 @@ from torchvision import transforms
 from torchvision.datasets import ImageFolder
 
 
+class ImageFolderWithFilenames(ImageFolder):
+    """ImageFolder extension that also returns a domain-prefixed file stem."""
+
+    def __getitem__(self, index):
+        img, target = super().__getitem__(index)
+        path, _ = self.samples[index]
+        path = Path(path)
+        domain = path.parent.name
+        fname = f'{domain}_{path.stem}' if domain else path.stem
+        return img, target, fname
+
+
 def listdir(dname):
     fnames = list(chain(*[list(Path(dname).rglob('*.' + ext))
                           for ext in ['png', 'jpg', 'jpeg', 'JPG']]))
@@ -184,7 +196,7 @@ def get_eval_loader(root, img_size=256, batch_size=32,
 
 
 def get_test_loader(root, img_size=256, batch_size=32,
-                    shuffle=True, num_workers=4):
+                    shuffle=True, num_workers=4, return_paths=False):
     print('Preparing DataLoader for the generation phase...')
     if isinstance(img_size, tuple):
         height, width = img_size
@@ -198,7 +210,10 @@ def get_test_loader(root, img_size=256, batch_size=32,
                              std=[0.5, 0.5, 0.5]),
     ])
 
-    dataset = ImageFolder(root, transform)
+    if return_paths:
+        dataset = ImageFolderWithFilenames(root, transform)
+    else:
+        dataset = ImageFolder(root, transform)
     return data.DataLoader(dataset=dataset,
                            batch_size=batch_size,
                            shuffle=shuffle,

--- a/core/data_loader.py
+++ b/core/data_loader.py
@@ -25,14 +25,12 @@ from torchvision.datasets import ImageFolder
 
 
 class ImageFolderWithFilenames(ImageFolder):
-    """ImageFolder extension that also returns a domain-prefixed file stem."""
+    """ImageFolder extension that also returns the original filename."""
 
     def __getitem__(self, index):
         img, target = super().__getitem__(index)
         path, _ = self.samples[index]
-        path = Path(path)
-        domain = path.parent.name
-        fname = f'{domain}_{path.stem}' if domain else path.stem
+        fname = Path(path).name
         return img, target, fname
 
 
@@ -40,6 +38,21 @@ def listdir(dname):
     fnames = list(chain(*[list(Path(dname).rglob('*.' + ext))
                           for ext in ['png', 'jpg', 'jpeg', 'JPG']]))
     return fnames
+
+
+def _analyze_directory(root):
+    """Return booleans indicating whether a directory has images or sub-directories."""
+    root = Path(root)
+    has_images = False
+    has_subdirs = False
+    for entry in root.iterdir():
+        if entry.is_dir():
+            has_subdirs = True
+        elif entry.is_file() and entry.suffix.lower() in {'.png', '.jpg', '.jpeg'}:
+            has_images = True
+        if has_images and has_subdirs:
+            break
+    return has_images, has_subdirs
 
 # Center-crop to match the target aspect ratio, then resize
 class CenterCropResize:
@@ -210,10 +223,21 @@ def get_test_loader(root, img_size=256, batch_size=32,
                              std=[0.5, 0.5, 0.5]),
     ])
 
+    has_images, has_subdirs = _analyze_directory(root)
     if return_paths:
-        dataset = ImageFolderWithFilenames(root, transform)
+        if has_subdirs:
+            dataset = ImageFolderWithFilenames(root, transform)
+        elif has_images:
+            dataset = DefaultDataset(root, transform=transform, return_paths=True)
+        else:
+            raise ValueError(f'No image files found in {root}')
     else:
-        dataset = ImageFolder(root, transform)
+        if has_subdirs:
+            dataset = ImageFolder(root, transform)
+        elif has_images:
+            dataset = DefaultDataset(root, transform=transform)
+        else:
+            raise ValueError(f'No image files found in {root}')
     return data.DataLoader(dataset=dataset,
                            batch_size=batch_size,
                            shuffle=shuffle,

--- a/core/solver.py
+++ b/core/solver.py
@@ -12,6 +12,7 @@ import os
 from os.path import join as ospj
 import time
 import datetime
+from collections import defaultdict
 from munch import Munch
 
 import torch
@@ -188,6 +189,112 @@ class Solver(nn.Module):
         fname = ospj(args.result_dir, 'video_ref.mp4')
         print('Working on {}...'.format(fname))
         utils.video_ref(nets_ema, args, src.x, ref.x, ref.y, fname)
+
+    @torch.no_grad()
+    def generate(self, loaders, args):
+        nets_ema = self.nets_ema
+        os.makedirs(args.result_dir, exist_ok=True)
+        self._load_checkpoint(args.resume_iter)
+
+        for net in nets_ema.values():
+            net.eval()
+
+        src_loader = loaders.src
+        class_to_idx = getattr(src_loader.dataset, 'class_to_idx', {})
+        idx_to_class = {idx: name for name, idx in class_to_idx.items()}
+        if hasattr(loaders, 'ref'):
+            ref_class_to_idx = getattr(loaders.ref.dataset, 'class_to_idx', {})
+            for name, idx in ref_class_to_idx.items():
+                idx_to_class.setdefault(idx, name)
+
+        def _parse_target(target):
+            if target is None:
+                return list(range(args.num_domains))
+            if isinstance(target, str):
+                token = target.strip()
+                if token in idx_to_class.values():
+                    indices = [idx for idx, name in idx_to_class.items() if name == token]
+                    if indices:
+                        return indices
+                    raise ValueError('Unknown target_domain: %s' % target)
+                if token.isdigit():
+                    idx = int(token)
+                else:
+                    raise ValueError('Unknown target_domain: %s' % target)
+            else:
+                idx = int(target)
+            if idx < 0 or idx >= args.num_domains:
+                raise ValueError('target_domain %s is out of range [0, %d).' % (target, args.num_domains))
+            return [idx]
+
+        target_domains = sorted(set(_parse_target(args.target_domain)))
+        if not target_domains:
+            raise ValueError('No target domains available for generation.')
+
+        use_references = hasattr(loaders, 'ref')
+        style_cache = {idx: [] for idx in target_domains}
+
+        if args.num_samples < 1:
+            raise ValueError('num_samples must be a positive integer.')
+
+        if use_references:
+            ref_loader = loaders.ref
+            for x_ref, y_ref, _ in ref_loader:
+                x_ref = x_ref.to(self.device)
+                y_ref = y_ref.to(self.device)
+                styles = nets_ema.style_encoder(x_ref, y_ref)
+                for style, label in zip(styles, y_ref):
+                    label_idx = int(label.item())
+                    if label_idx in style_cache and len(style_cache[label_idx]) < args.num_samples:
+                        style_cache[label_idx].append(style.detach().cpu())
+                if all(len(style_cache[idx]) >= args.num_samples for idx in target_domains):
+                    break
+
+            available_domains = [idx for idx in target_domains if len(style_cache[idx]) > 0]
+            missing_domains = [idx for idx in target_domains if len(style_cache[idx]) == 0]
+            if missing_domains:
+                domain_list = ', '.join(idx_to_class.get(idx, str(idx)) for idx in missing_domains)
+                if len(available_domains) == 0:
+                    print('No reference images found for %s. Falling back to latent sampling.' % domain_list)
+                    use_references = False
+                else:
+                    print('Skipping domains without references: %s' % domain_list)
+                    target_domains = available_domains
+
+        if not use_references:
+            print('Generating samples using latent codes for domains: {}'
+                  .format(', '.join(idx_to_class.get(idx, str(idx)) for idx in target_domains)))
+
+        for net in self.nets.values():
+            net.eval()
+
+        counters = defaultdict(int)
+
+        for x_src, _, names in src_loader:
+            x_src = x_src.to(self.device)
+            batch_size = x_src.size(0)
+
+            for domain_idx in target_domains:
+                y_trg = torch.full((batch_size,), domain_idx, dtype=torch.long, device=self.device)
+                for sample_idx in range(args.num_samples):
+                    if use_references:
+                        styles = style_cache[domain_idx]
+                        if not styles:
+                            continue
+                        style_code = styles[sample_idx % len(styles)].to(self.device)
+                        style_code = style_code.unsqueeze(0).repeat(batch_size, 1)
+                    else:
+                        z_trg = torch.randn(batch_size, args.latent_dim).to(self.device)
+                        style_code = nets_ema.mapping_network(z_trg, y_trg)
+
+                    x_fake = nets_ema.generator(x_src, style_code, masks=None)
+
+                    for i, name in enumerate(names):
+                        base_name = str(name)
+                        counters[base_name] += 1
+                        outfile = ospj(args.result_dir, f'{base_name}_{counters[base_name]:02d}.png')
+                        utils.save_image(x_fake[i:i+1], 1, outfile)
+                        print('Saved {}'.format(outfile))
 
     @torch.no_grad()
     def sample_with_latent(self, loaders):

--- a/core/solver.py
+++ b/core/solver.py
@@ -13,6 +13,7 @@ from os.path import join as ospj
 import time
 import datetime
 from collections import defaultdict
+from pathlib import Path
 from munch import Munch
 
 import torch
@@ -245,13 +246,11 @@ class Solver(nn.Module):
                 styles = nets_ema.style_encoder(x_ref, y_ref)
                 for style, label in zip(styles, y_ref):
                     label_idx = int(label.item())
-                    if label_idx in style_cache and len(style_cache[label_idx]) < args.num_samples:
+                    if label_idx in style_cache:
                         style_cache[label_idx].append(style.detach().cpu())
-                if all(len(style_cache[idx]) >= args.num_samples for idx in target_domains):
-                    break
 
-            available_domains = [idx for idx in target_domains if len(style_cache[idx]) > 0]
-            missing_domains = [idx for idx in target_domains if len(style_cache[idx]) == 0]
+            available_domains = [idx for idx in target_domains if style_cache[idx]]
+            missing_domains = [idx for idx in target_domains if not style_cache[idx]]
             if missing_domains:
                 domain_list = ', '.join(idx_to_class.get(idx, str(idx)) for idx in missing_domains)
                 if len(available_domains) == 0:
@@ -260,6 +259,11 @@ class Solver(nn.Module):
                 else:
                     print('Skipping domains without references: %s' % domain_list)
                     target_domains = available_domains
+                    style_cache = {idx: style_cache[idx] for idx in target_domains}
+
+        if use_references:
+            style_cache = {idx: torch.stack(style_cache[idx], dim=0)
+                           for idx in target_domains}
 
         if not use_references:
             print('Generating samples using latent codes for domains: {}'
@@ -270,27 +274,58 @@ class Solver(nn.Module):
 
         counters = defaultdict(int)
 
-        for x_src, _, names in src_loader:
+        for batch in src_loader:
+            if len(batch) == 3:
+                x_src, y_src, names = batch
+            elif len(batch) == 2:
+                x_src, names = batch
+                y_src = None
+            else:
+                raise ValueError('Unexpected batch structure from src loader.')
+
             x_src = x_src.to(self.device)
             batch_size = x_src.size(0)
+
+            if isinstance(names, (list, tuple)):
+                name_list = list(names)
+            else:
+                name_list = [names]
+
+            if y_src is not None:
+                if torch.is_tensor(y_src):
+                    label_list = y_src.tolist()
+                elif isinstance(y_src, (list, tuple)):
+                    label_list = list(y_src)
+                else:
+                    label_list = [int(y_src)]
+            else:
+                label_list = [None] * len(name_list)
+
+            if len(name_list) != batch_size:
+                raise ValueError('Mismatch between filenames and batch size in source loader.')
 
             for domain_idx in target_domains:
                 y_trg = torch.full((batch_size,), domain_idx, dtype=torch.long, device=self.device)
                 for sample_idx in range(args.num_samples):
                     if use_references:
                         styles = style_cache[domain_idx]
-                        if not styles:
+                        if styles.size(0) == 0:
                             continue
-                        style_code = styles[sample_idx % len(styles)].to(self.device)
-                        style_code = style_code.unsqueeze(0).repeat(batch_size, 1)
+                        idxs = torch.randint(0, styles.size(0), (batch_size,), device=styles.device)
+                        style_code = styles[idxs].to(self.device)
                     else:
                         z_trg = torch.randn(batch_size, args.latent_dim).to(self.device)
                         style_code = nets_ema.mapping_network(z_trg, y_trg)
 
                     x_fake = nets_ema.generator(x_src, style_code, masks=None)
 
-                    for i, name in enumerate(names):
-                        base_name = str(name)
+                    for i, name in enumerate(name_list):
+                        base_name = Path(name).stem
+                        if i < len(label_list) and label_list[i] is not None:
+                            domain_name = idx_to_class.get(int(label_list[i]), '')
+                            prefix = f'{domain_name}_'
+                            if domain_name and base_name.startswith(prefix):
+                                base_name = base_name[len(prefix):]
                         counters[base_name] += 1
                         outfile = ospj(args.result_dir, f'{base_name}_{counters[base_name]:02d}.png')
                         utils.save_image(x_fake[i:i+1], 1, outfile)

--- a/main.py
+++ b/main.py
@@ -73,6 +73,26 @@ def main(args):
                                             num_workers=args.num_workers))
         solver.sample(loaders)
 
+    elif args.mode == 'generate':
+        if not os.path.isdir(args.src_dir):
+            raise ValueError(f'Source directory not found: {args.src_dir}')
+
+        loaders = Munch(src=get_test_loader(root=args.src_dir,
+                                            img_size=(args.img_height, args.img_width),
+                                            batch_size=args.val_batch_size,
+                                            shuffle=False,
+                                            num_workers=args.num_workers,
+                                            return_paths=True))
+
+        if args.ref_dir and os.path.isdir(args.ref_dir):
+            loaders.ref = get_test_loader(root=args.ref_dir,
+                                          img_size=(args.img_height, args.img_width),
+                                          batch_size=args.val_batch_size,
+                                          shuffle=True,
+                                          num_workers=args.num_workers,
+                                          return_paths=True)
+        solver.generate(loaders, args)
+
     elif args.mode == 'latent_sample':
         assert len(subdirs(args.src_dir)) == args.num_domains
         loaders = Munch(src=get_test_loader(root=args.src_dir,
@@ -145,10 +165,12 @@ if __name__ == '__main__':
                         help='Weight decay for optimizer')
     parser.add_argument('--num_outs_per_domain', type=int, default=4,
                         help='Number of generated images per domain during sampling')
+    parser.add_argument('--num_samples', type=int, default=1,
+                        help='Number of generated images per source during quick generation')
 
     # misc
     parser.add_argument('--mode', type=str, required=True,
-                        choices=['train', 'sample', 'eval', 'align', 'latent_sample'],
+                        choices=['train', 'sample', 'eval', 'align', 'latent_sample', 'generate'],
                         help='This argument is used in solver')
     parser.add_argument('--num_workers', type=int, default=4,
                         help='Number of workers used in DataLoader')
@@ -182,6 +204,8 @@ if __name__ == '__main__':
                         help='Directory containing input source images')
     parser.add_argument('--ref_dir', type=str, default='assets/representative/celeba_hq/ref',
                         help='Directory containing input reference images')
+    parser.add_argument('--target_domain', type=str, default=None,
+                        help='Optional target domain name or index for quick generation')
     parser.add_argument('--inp_dir', type=str, default='assets/representative/custom/female',
                         help='input directory when aligning faces')
     parser.add_argument('--out_dir', type=str, default='assets/representative/celeba_hq/src/female',


### PR DESCRIPTION
## Summary
- add a `generate` CLI mode with supporting arguments that reuses the existing loaders
- implement `Solver.generate` to emit per-image outputs using reference codes or latent sampling
- extend the test data loader to surface filenames and document the workflow in the README

## Testing
- python -m compileall main.py core

------
https://chatgpt.com/codex/tasks/task_e_68c8b2027160832283e4670c02c922cf